### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,10 @@ async with EmpathyOS() as empathy:
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/smart-ai-memory-empathy-framework).
+
 ## Command Hubs
 
 Workflows are organized into hubs for easy discovery:


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/smart-ai-memory-empathy-framework).